### PR TITLE
fixed bug issue 76 by modifying modelfactory.py

### DIFF
--- a/src/models/modelfactory.py
+++ b/src/models/modelfactory.py
@@ -90,6 +90,7 @@ class ModelFactory:
             ModelClass = MetaModelWA if type == 'meta_wa' else MetaModelLR
             if params.get('preprocessors') is None:
                 # If not custom preprocessors, use default META_PREPROCESSORS
+                del params['preprocessors']
                 predictor = ModelClass(type=type, scorers=scorer_funcs, **params)
                 params.setdefault('preprocessors', META_PREPROCESSORS)
             else:


### PR DESCRIPTION
Fixed the bug issue #76 by adding `del params['preprocessors']` in line 93 in `modelfactory.py`.

Now it looks like this:
```
           if params.get('preprocessors') is None:
                # If not custom preprocessors, use default META_PREPROCESSORS
                del params['preprocessors']
                predictor = ModelClass(type=type, scorers=scorer_funcs, **params)
                params.setdefault('preprocessors', META_PREPROCESSORS)
```
