### PR TITLE
Fixed issue 92 and typo in _create_preprocessors

### DIFF
--- a/src/models/modelfactory.py
+++ b/src/models/modelfactory.py
@@ -97,7 +97,6 @@ class ModelFactory:
             ModelClass = MetaModelWA if type == 'meta_wa' else MetaModelLR
             if params.get('preprocessors') is None:
                 # If not custom preprocessors, use default META_PREPROCESSORS
-                del params['preprocessors']
                 predictor = ModelClass(type=type, scorers=scorer_funcs, **params)
                 params.setdefault('preprocessors', META_PREPROCESSORS)
             else:
@@ -154,7 +153,7 @@ class ModelFactory:
                              'simpleimputer': SimpleImputer,
                              'dartsimputer': DartsImputer}
         type = preprocessor.get('type')
-        kwargs = preprocessor.get('param', {})
+        kwargs = preprocessor.get('params', {})
         if type in preprocessors_map:
             return preprocessors_map.get(type)(**kwargs)
         else:


### PR DESCRIPTION
Fixed #92 by deleting the line https://github.com/Tempor-ai/sybil/blob/83878b9ef8cab4897c933b9e2d60fe805bdd234e/src/models/modelfactory.py#L100

Initially it was added in #77 because `params` in https://github.com/Tempor-ai/sybil/blob/83878b9ef8cab4897c933b9e2d60fe805bdd234e/src/models/modelfactory.py#L98
was `{'preprocessors': None, 'base_models': [<models.modelwrappers.DartsWrapper object at 0x00000213DE514F70>]}` when `preprocessors` is not specified in model_request, thus raising an error in #76 

But now, after several changes in m8-staging (to be investigated), `params` is 
`{'base_models': [<models.modelwrappers.DartsWrapper object at 0x000001F89A3029A0>]}` , where `preprocessors` won't appear when not specified in customized model_request. Therefore getting the KeyError in issue 92. To resolve this issue, deleted the previously added line since it won't be needed anymore. 

Also fixed typo 'param' to 'params' in _create_preprocessors so now the preprocessors sub-param can be correctly retrieved.